### PR TITLE
OSSCollectionStandbyReplicasのDescriptionを変更

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -24,7 +24,7 @@ Parameters:
   OSSCollectionStandbyReplicas:
     Type: String
     Default: 'DISABLED'
-    Description: 'DISABLED is suitable for production environments. ENABLED is suitable for development environments.'
+    Description: 'ENABLED is suitable for production environments. DISABLED is suitable for development environments.'
     AllowedValues:
       - 'DISABLED'
       - 'ENABLED'


### PR DESCRIPTION
こちらの [記事](https://dev.classmethod.jp/articles/sam-knowledge-base-for-bedrock-with-oss/) 参考にさせていただいています！

コード拝見して、 `OSSCollectionStandbyReplicas` の説明がproductionとdevelopmentで逆かなと思いましたのでPRださせていただきました。